### PR TITLE
DM: Generate vRPMB key when creating UOS

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -101,6 +101,7 @@ SRCS += core/vmmapi.c
 SRCS += core/mptbl.c
 SRCS += core/main.c
 SRCS += core/hugetlb.c
+SRCS += core/vrpmb.c
 
 # arch
 SRCS += arch/x86/pm.c

--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -182,8 +182,11 @@ struct acrn_create_vm {
 	 */
 	uint64_t vm_flag;
 
+	/** virtual RPMB key GVA for this VM */
+	uint64_t vrpmb_key_gva;
+
 	/** Reserved for future use*/
-	uint8_t  reserved[24];
+	uint8_t  reserved[16];
 } __aligned(8);
 
 /**

--- a/devicemodel/include/vrpmb.h
+++ b/devicemodel/include/vrpmb.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef _VRPMB_
+#define _VRPMB_
+
+#define RPMB_KEY_LEN 64
+
+int get_vrpmb_key(uint8_t *out);
+
+#endif /* _VRPMB_ */


### PR DESCRIPTION
Generate virtual RPMB key and pass it to HV when
create UOS.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>