### PR TITLE
HV: parse seed from ABL

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -194,7 +194,7 @@ C_SRCS += bsp/$(CONFIG_PLATFORM)/cmdline.c
 else
 ifeq ($(CONFIG_PLATFORM), sbl)
 C_SRCS += boot/sbl/multiboot.c
-C_SRCS += boot/sbl/hob_parse.c
+C_SRCS += boot/sbl/seed_parse.c
 endif
 endif
 

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -7,15 +7,22 @@
 #include <hypervisor.h>
 #include <multiboot.h>
 #include <zeropage.h>
-#include <hob_parse.h>
+#include <seed_parse.h>
 
 #define BOOT_ARGS_LOAD_ADDR				0x24EFC000
 
 #define ACRN_DBG_BOOT	6U
 
 #define MAX_BOOT_PARAMS_LEN 64U
+#define MMC_SERIAL_LEN 15U
 
-static const char *boot_params_arg = "ImageBootParamsAddr=";
+#define BOOT_PARAMS_SBL 0U
+#define BOOT_PARAMS_ABL 1U
+static const char *boot_params_arg[3] = {
+	"ImageBootParamsAddr=",
+	"dev_sec_info.param_addr=",
+	NULL
+};
 
 struct image_boot_params {
 	uint32_t size_of_this_struct;
@@ -116,6 +123,26 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
 	return kernel_src_addr;
 }
 
+static void get_emmc_serial(char *cmdline, uint8_t *serial)
+{
+	char *arg;
+	char *param;
+	uint32_t len;
+
+	len = strnlen_s("androidboot.serialno=", MEM_2K);
+	arg = strstr_s(cmdline, MEM_2K, "androidboot.serialno=", len);
+
+	if (arg == NULL) {
+		memcpy_s(serial, MMC_SERIAL_LEN, "123456789abcde", MMC_SERIAL_LEN);
+		return;
+	}
+
+	param = arg + len;
+
+	memcpy_s(serial, MMC_SERIAL_LEN, param, MMC_SERIAL_LEN-1);
+	serial[MMC_SERIAL_LEN-1] = '\0';
+}
+
 /*
  * parse_image_boot_params
  *
@@ -132,43 +159,71 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
  *    vm            pointer to vm structure
  *    cmdline       pointer to cmdline string
  *
+ * output:
+ *    index         pointer to argument index
+ *
  * return value:
- *    boot_params   HVA of image_boot_params if parse success, or
+ *    param_addr    HVA of image_boot_params if parse success, or
  *                  else a NULL pointer.
  */
-static void *parse_image_boot_params(struct vm *vm, char *cmdline)
+static void *parse_image_boot_params(struct vm *vm, char *cmdline, uint32_t *index)
 {
 	char *arg, *arg_end;
 	char *param;
-	uint32_t len;
+	uint8_t serial[15];
+	void *param_addr;
 	struct image_boot_params *boot_params;
+	uint32_t len;
+	uint32_t i = 0;
 
 	if (cmdline == NULL) {
 		goto fail;
 	}
 
-	len = strnlen_s(boot_params_arg, MAX_BOOT_PARAMS_LEN);
-	arg = strstr_s(cmdline, MEM_2K, boot_params_arg, len);
+	while (boot_params_arg[i] != NULL) {
+		len = strnlen_s(boot_params_arg[i], MAX_BOOT_PARAMS_LEN);
+		arg = strstr_s(cmdline, MEM_2K, boot_params_arg[i], len);
+		if (arg)
+			break;
+		i++;
+	}
+
 	if (arg == NULL) {
 		goto fail;
 	}
 
+	if (index) {
+		*index = i;
+	}
+
 	param = arg + len;
-	boot_params = (struct image_boot_params *)hpa2hva(strtoul_hex(param));
-	if (boot_params == NULL) {
+	param_addr = (void *)hpa2hva(strtoul_hex(param));
+	if (param_addr == NULL) {
 		goto fail;
 	}
 
-	parse_seed_list((struct seed_list_hob *)hpa2hva(
+	switch (i) {
+	case BOOT_PARAMS_SBL:
+		boot_params = (struct image_boot_params *)param_addr;
+		parse_seed_list_sbl((struct seed_list_hob *)hpa2hva(
 				boot_params->p_seed_list));
 
-	/*
-	 * Convert the addresses to SOS GPA since this structure will be used
-	 * in SOS.
-	 */
-	boot_params->p_seed_list = hpa2gpa(vm, boot_params->p_seed_list);
-	boot_params->p_platform_info =
+		/*
+		 * Convert the addresses to SOS GPA since this structure will
+		 * be used in SOS.
+		 */
+		boot_params->p_seed_list =
+				hpa2gpa(vm, boot_params->p_seed_list);
+		boot_params->p_platform_info =
 				hpa2gpa(vm, boot_params->p_platform_info);
+		break;
+	case BOOT_PARAMS_ABL:
+		get_emmc_serial(cmdline, serial);
+		parse_seed_list_abl(param_addr, serial, 14);
+		break;
+	default:
+		goto fail;
+	}
 
 	/*
 	 * Replace original arguments with spaces since SOS's GPA is not
@@ -180,10 +235,10 @@ static void *parse_image_boot_params(struct vm *vm, char *cmdline)
 							strnlen_s(arg, MEM_2K);
 	(void)memset(arg, ' ', len);
 
-	return (void *)boot_params;
+	return (void *)param_addr;
 
 fail:
-	parse_seed_list(NULL);
+	parse_seed_list_sbl(NULL);
 	return NULL;
 }
 
@@ -287,12 +342,14 @@ int init_vm_boot_info(struct vm *vm)
 		char *cmd_src, *cmd_dst;
 		uint32_t off = 0U;
 		void *boot_params_addr;
+		uint32_t index = 0U;
 		char buf[MAX_BOOT_PARAMS_LEN];
 
 		cmd_dst = kernel_cmdline;
 		cmd_src = hpa2hva((uint64_t)mbi->mi_cmdline);
 
-		boot_params_addr = parse_image_boot_params(vm, cmd_src);
+		boot_params_addr = parse_image_boot_params(vm, cmd_src, &index);
+
 		/*
 		 * Convert ImageBootParamsAddr to SOS GPA and append to
 		 * kernel cmdline
@@ -300,7 +357,7 @@ int init_vm_boot_info(struct vm *vm)
 		if (boot_params_addr != NULL) {
 			(void)memset(buf, 0U, sizeof(buf));
 			snprintf(buf, MAX_BOOT_PARAMS_LEN, "%s0x%X ",
-				boot_params_arg, hva2gpa(vm, boot_params_addr));
+				boot_params_arg[index], hva2gpa(vm, boot_params_addr));
 			(void)strncpy_s(cmd_dst, MEM_2K, buf,
 						MAX_BOOT_PARAMS_LEN);
 			off = strnlen_s(cmd_dst, MEM_2K);

--- a/hypervisor/boot/sbl/seed_parse.c
+++ b/hypervisor/boot/sbl/seed_parse.c
@@ -5,9 +5,10 @@
  */
 
 #include <hypervisor.h>
-#include <hob_parse.h>
+#include <seed_parse.h>
+#include <hkdf_wrap.h>
 
-void parse_seed_list(struct seed_list_hob *seed_hob)
+void parse_seed_list_sbl(struct seed_list_hob *seed_hob)
 {
 	uint8_t i;
 	uint8_t dseed_index = 0U;
@@ -63,6 +64,45 @@ void parse_seed_list(struct seed_list_hob *seed_hob)
 	(void)memset(dseed_list, 0U, sizeof(dseed_list));
 	return;
 
+fail:
+	trusty_set_dseed(NULL, 0U);
+	(void)memset(dseed_list, 0U, sizeof(dseed_list));
+}
+
+void parse_seed_list_abl(void *boot_params, uint8_t *serial, uint32_t serial_len)
+{
+	uint32_t i;
+	struct seed_info dseed_list[BOOTLOADER_SEED_MAX_ENTRIES];
+	struct dev_sec_info *sec_info = (struct dev_sec_info *)boot_params;
+
+	if (sec_info == NULL)
+		goto fail;
+
+	(void)memset(dseed_list, 0U, sizeof(dseed_list));
+	for (i = 0U; i < sec_info->num_seeds; i++) {
+		dseed_list[i].cse_svn = sec_info->seed_list[i].svn;
+		(void)memcpy_s(dseed_list[i].seed,
+				sizeof(dseed_list[i].seed),
+				sec_info->seed_list[i].seed,
+				sizeof(sec_info->seed_list[i].seed));
+
+		/* replace original seeds with new seeds(derived with emmc serial) */
+		if (hkdf_sha256(sec_info->seed_list[i].seed,
+				sizeof(sec_info->seed_list[i].seed),
+				dseed_list[i].seed,
+				sizeof(dseed_list[i].seed),
+				NULL, 0U,
+				serial, serial_len) == 0U) {
+			/* Failed derive key, use fake seed */
+			(void)memset(sec_info->seed_list[i].seed, 0xFA,
+					sizeof(sec_info->seed_list[i].seed));
+		}
+	}
+
+
+	trusty_set_dseed(dseed_list, sec_info->num_seeds);
+	(void)memset(dseed_list, 0U, sizeof(dseed_list));
+	return;
 fail:
 	trusty_set_dseed(NULL, 0U);
 	(void)memset(dseed_list, 0U, sizeof(dseed_list));

--- a/hypervisor/include/arch/x86/seed_parse.h
+++ b/hypervisor/include/arch/x86/seed_parse.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef HOB_PARSE_H_
-#define HOB_PARSE_H_
+#ifndef SEED_PARSE_H_
+#define SEED_PARSE_H_
 
 #define SEED_ENTRY_TYPE_SVNSEED         0x1U
 #define SEED_ENTRY_TYPE_RPMBSEED        0x2U
@@ -41,6 +41,24 @@ struct seed_entry {
 	uint8_t seed[0];
 };
 
-void parse_seed_list(struct seed_list_hob *seed_hob);
+void parse_seed_list_sbl(struct seed_list_hob *seed_hob);
 
-#endif /* HOB_PARSE_H_ */
+
+#define ABL_SEED_LEN 32U
+struct abl_seed_info {
+	uint8_t svn;
+	uint8_t reserved[3];
+	uint8_t seed[ABL_SEED_LEN];
+};
+
+#define ABL_SEED_LIST_MAX 4U
+struct dev_sec_info {
+	uint32_t size_of_this_struct;
+	uint32_t version;
+	uint32_t num_seeds;
+	struct abl_seed_info seed_list[ABL_SEED_LIST_MAX];
+};
+
+void parse_seed_list_abl(void *boot_params, uint8_t *serial, uint32_t serial_len);
+
+#endif /* SEED_PARSE_H_ */


### PR DESCRIPTION
ABL pass seed_lists to HV through different interface/structures.
So, in this patch, add interface to retrieve seed from ABL and refactor
the seed parsing logic.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>