### PR TITLE
hv: trusty: save/restore tsc for secure world

### DIFF
--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -522,6 +522,8 @@ void trusty_set_dseed(const void *dseed, uint8_t dseed_num)
 
 void save_sworld_context(struct acrn_vcpu *vcpu)
 {
+	vcpu->arch.contexts[SECURE_WORLD].ext_ctx.tsc_offset += rdtsc();
+
 	(void)memcpy_s(&vcpu->vm->sworld_snapshot,
 			sizeof(struct cpu_context),
 			&vcpu->arch.contexts[SECURE_WORLD],
@@ -542,6 +544,8 @@ void restore_sworld_context(struct acrn_vcpu *vcpu)
 			sizeof(struct cpu_context),
 			&vcpu->vm->sworld_snapshot,
 			sizeof(struct cpu_context));
+
+	vcpu->arch.contexts[SECURE_WORLD].ext_ctx.tsc_offset -= rdtsc();
 }
 
 /**


### PR DESCRIPTION
TSC would be reset to 0 when enter suspend state. This would
fail the secure timer checking in secure world because secure
world leverage the TSC as source of secure timer which should be
increased monotonously.

This patch save/restore in secure world suspend/resume path to
guarantee the mono increasing TSC of secure world.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>